### PR TITLE
 updates to allow external cloud provider

### DIFF
--- a/modules/userdata/files/rke2-init.sh
+++ b/modules/userdata/files/rke2-init.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 export TYPE="${type}"
-export CCM="true"
-export CCM_EXTERNAL="true"
+export CCM="${ccm}"
+export CCM_EXTERNAL="${ccm_external}"
 
 # info logs the given argument at info log level.
 info() {

--- a/modules/userdata/files/rke2-init.sh
+++ b/modules/userdata/files/rke2-init.sh
@@ -159,6 +159,14 @@ upload() {
     if [ $CCM_EXTERNAL = "true" ]; then
       append_config 'cloud-provider-name: "external"'
       append_config 'disable-cloud-controller: "true"'
+      TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      AZ=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone)
+      IID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+      mkdir -p /etc/rancher/rke2/config.d/
+      tee /etc/rancher/rke2/config.d/kubelet-config.yaml <<EOF
+kubelet-arg:
+  - provider-id=aws:///$AZ/$IID
+EOF
     else
       append_config 'cloud-provider-name: "aws"'
     fi


### PR DESCRIPTION
This PR makes the modifications required to allow the external cloud provider.
1. Gets a token to be used to query the nodes metadata 
2. Saves the nodes availability zone and instance id in ENV vars.
3. Creates the /etc/rancher/rke2/config.d directory 
4. Creates a file named kubelet-config.yaml inside /etc/rancher/rke2/config.d using the values retrieved from the metadata to configure kubelet flags needed for external cloud provider. 